### PR TITLE
Add otherguy/php-currency-api API Wrapper to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ fetch('https://api.exchangeratesapi.io/latest')
 ```
 
 ## API wrappers
-* PHP - [https://github.com/benmajor/ExchangeRatesAPI](https://github.com/benmajor/ExchangeRatesAPI)
+### PHP 
+  - [https://github.com/benmajor/ExchangeRatesAPI](https://github.com/benmajor/ExchangeRatesAPI)
+  - [`otherguy/php-currency-api`](https://github.com/otherguy/php-currency-api)
 
 ## Stack
 


### PR DESCRIPTION
Thank you for the useful (and free!) API. I've added support for it in my [`otherguy/php-currency-api`](https://github.com/otherguy/php-currency-api) package.

Would you consider adding it to the `README`?