### PR TITLE
Add TypeScript client to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ fetch('https://api.exchangeratesapi.io/latest')
 
 ## API wrappers
 * PHP - [https://github.com/benmajor/ExchangeRatesAPI](https://github.com/benmajor/ExchangeRatesAPI)
+* TypeScript - [https://github.com/ToeFungi/exchange-rates-as-promised](https://github.com/ToeFungi/exchange-rates-as-promised)
 
 ## Stack
 


### PR DESCRIPTION
Hi, 

I've created a TypeScript client for this API. Would be great if it could be included in the README. The client is a promise-based client, covered 100% with unit tests, runs a Travis build which runs the tests, audit and linting as well as runs static analysis with SonarCloud.

https://travis-ci.org/ToeFungi/exchange-rates-as-promised/branches
https://sonarcloud.io/dashboard?id=exchange-rates-as-promised
https://www.npmjs.com/package/exchange-rates-as-promised