### PR TITLE
Added the Laravel Exchange Rates API wrapper to the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ fetch('https://api.exchangeratesapi.io/latest')
 
 ## API wrappers
 * PHP - [https://github.com/benmajor/ExchangeRatesAPI](https://github.com/benmajor/ExchangeRatesAPI)
+* Laravel (PHP) - [https://github.com/ash-jc-allen/laravel-exchange-rates](https://github.com/ash-jc-allen/laravel-exchange-rates)
 
 ## Stack
 


### PR DESCRIPTION
This PR adds a link to the ash-jc-allen/laravel-exchange-rates API wrapper to the README file