### PR TITLE
Ruby API Wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ fetch('https://api.exchangeratesapi.io/latest')
 
 ## API wrappers
 * PHP - [https://github.com/benmajor/ExchangeRatesAPI](https://github.com/benmajor/ExchangeRatesAPI)
+* Ruby - [https://github.com/overchind/ECBExchangeRatesApi](https://github.com/overchind/ECBExchangeRatesApi)
 
 ## Stack
 


### PR DESCRIPTION
I want to present my version of ruby API wrapper for ExchangeRatesAPI. As I mentioned in the letter, for now, version 0.1.2 is ready. Ruby gem was written within rubocop style guides and covered by rspec test library. I'm going to add more documentation, examples and extra features in the future versions.