### PR TITLE
Add otherguy/php-currency-api API Wrapper to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ fetch('https://api.exchangeratesapi.io/latest')
 ## API wrappers
 * PHP - [https://github.com/benmajor/ExchangeRatesAPI](https://github.com/benmajor/ExchangeRatesAPI)
 * Laravel (PHP) - [https://github.com/ash-jc-allen/laravel-exchange-rates](https://github.com/ash-jc-allen/laravel-exchange-rates)
+* Laravel / PHP - [`otherguy/php-currency-api`](https://github.com/otherguy/php-currency-api)
 
 ## Stack
 


### PR DESCRIPTION
Supersedes https://github.com/exchangeratesapi/exchangeratesapi/pull/50

---

Thank you for the useful (and free!) API. I've added support for it in my [`otherguy/php-currency-api`](https://github.com/otherguy/php-currency-api) package.

Would you consider adding it to the `README`?